### PR TITLE
Fix strike zone top/bottom bug

### DIFF
--- a/package/predpitchscore/R/get_trackman_metrics.R
+++ b/package/predpitchscore/R/get_trackman_metrics.R
@@ -31,10 +31,10 @@ get_trackman_metrics <- function(data) {
       plate_z_line = bz * plate_time + cz,
       plate_z_gravity = gravity * plate_time^2 / 2 + bz * plate_time + cz,
 
-      # I'm reconstructing these from memory, so not 100% sure they're correct
-      horz_break = plate_x - plate_x_line,
-      vert_break = plate_z - plate_z_line,
-      induced_vert_break = plate_z - plate_z_gravity,
+      # SP: I'm reconstructing these from memory, so not 100% sure they're correct
+      horz_break = 12 * (plate_x - plate_x_line),               # measured in inches
+      vert_break = 12 * (plate_z - plate_z_line),               # measured in inches
+      induced_vert_break = 12 * (plate_z - plate_z_gravity),    # measured in inches
 
       # Also recover the TrackMan metrics necessary for calculating the quadratic coefficients
       # t0 is the time when y = 50 (necessary for calculating velocity and x/z location at time t0)

--- a/scripts/fit_descriptive_models.R
+++ b/scripts/fit_descriptive_models.R
@@ -3,8 +3,8 @@ library(predpitchscore)
 
 year <- 2022
 fit_hit_model <- TRUE
-pitch_components <- c("swing", "hbp", "strike", "contact", "fair", "hit", "value"),
-stuff_components <- c("swing", "hbp", "strike", "contact", "fair", "hit", "value"),
+pitch_components <- c("swing", "hbp", "strike", "contact", "fair", "hit", "value")
+stuff_components <- c("swing", "hbp", "strike", "contact", "fair", "hit", "value")
 tune <- FALSE
 verbose <- TRUE
 


### PR DESCRIPTION
This is my favorite bug in a long time. It turns out that `strike_zone_top` and `strike_zone_bottom` are almost always rounded to two digits when the batter swings but not rounded when the batter takes a pitch. This threw a massive wrench into our gradient boosting model for predicting whether the batter would swing because the swing decision was leaking into the predictors. The model was learning with very high confidence that pitches in the dirt would be swung at (as long as `strike_zone_bottom` was rounded two digits), and this would be validated out of sample, so it looked like the model was generalizing well. Alas, this was not the case.

I fixed the problem by always rounding the strike zone features to two digits. I made a couple other minor fixes while I was at it.