### PR TITLE
Generalize pitch distribution estimation

### DIFF
--- a/package/predpitchscore/R/simulate_pitch_score.R
+++ b/package/predpitchscore/R/simulate_pitch_score.R
@@ -24,9 +24,9 @@ simulate_pitch_score <- function(pitcher_id, n, context, pitch_distrib_model, pi
   ) |>
     get_trackman_metrics()
   
-  simmed_pitch$is_rhb <- as.numeric(simmed_pitch$bat_side=="R")
+  simmed_pitch$is_rhb <- as.numeric(simmed_pitch$bat_side == "R")
 
-    pred <- predict(
+  pred <- predict(
     object = pitch_outcome_model,
     newpitch = simmed_pitch
   )


### PR DESCRIPTION
This PR generalizes pitch distribution estimation in two ways:
1. We can estimate either the "complete" or the "conditional" version of the model.
2. We can specify even/odd training split as a logical argument at the top of the script.